### PR TITLE
use  Dockerfile  when fatpack

### DIFF
--- a/maint/Dockerfile
+++ b/maint/Dockerfile
@@ -1,4 +1,4 @@
-FROM perl:5.10
+FROM perl:latest
 
 RUN curl --compressed -sSL https://git.io/cpm -o /usr/local/bin/cpm
 RUN chmod +x /usr/local/bin/cpm

--- a/maint/Dockerfile
+++ b/maint/Dockerfile
@@ -1,0 +1,7 @@
+FROM perl:5.10
+
+RUN curl --compressed -sSL https://git.io/cpm -o /usr/local/bin/cpm
+RUN chmod +x /usr/local/bin/cpm
+RUN cpm install -g App::FatPacker::Simple
+WORKDIR /p6-build/maint
+CMD ["make", "fatpack"]

--- a/maint/Makefile
+++ b/maint/Makefile
@@ -1,4 +1,6 @@
-fatpack: local
+.PHONY: fatpack local
+
+fatpack:local
 	fatpack-simple ../script/perl6-build -d ../lib,local -o ../bin/perl6-build --shebang '#!/usr/bin/env perl'
 
 local:

--- a/maint/Makefile
+++ b/maint/Makefile
@@ -4,4 +4,4 @@ fatpack:local
 	fatpack-simple ../script/perl6-build -d ../lib,local -o ../bin/perl6-build --shebang '#!/usr/bin/env perl'
 
 local:
-	cpm install --target-perl 5.10.1 --cpanfile ../cpanfile
+	cpm install --cpanfile ../cpanfile

--- a/maint/README.md
+++ b/maint/README.md
@@ -1,0 +1,9 @@
+# How to fatpack perl6-build
+
+## Docker
+
+```
+docker build -t perl6-build .
+docker run -v /path/to/local/perl6-build:/p6-build perl6-build
+```
+


### PR DESCRIPTION
perl6-build is use fatpack.
But, fatpack enviroments is very difficult at local.
So, I wrote Dockerfile like perl-build.

# difference
Add PHONY because the Makefile dependency was not used.

Removed `--target-perl` from cpm because it was not compatible with 5.10.1
